### PR TITLE
Implementing Parameter Separation in OpenAIHandler and Support for OpenAI-Compatible Servers

### DIFF
--- a/src/completion.ts
+++ b/src/completion.ts
@@ -20,6 +20,7 @@ import { MistralHandler } from './handlers/mistral';
 export const MODEL_HANDLER_MAPPINGS: Record<string, Handler> = {
   'claude-': AnthropicHandler,
   'gpt-': OpenAIHandler,
+  'openai/': OpenAIHandler,
   command: CohereHandler,
   'ollama/': OllamaHandler,
   'j2-': AI21Handler,

--- a/src/handlers/openai.ts
+++ b/src/handlers/openai.ts
@@ -47,7 +47,7 @@ export async function OpenAIHandler(
 ): Promise<ResultNotStreaming | ResultStreaming> {
   const { apiKey: providedApiKey, baseUrl: providedBaseUrl, ...completionsParams } = params;
   const apiKey = providedApiKey ?? process.env.OPENAI_API_KEY;
-  const baseUrl = providedBaseUrl ?? 'https://api.openai.com';
+  const baseUrl = providedBaseUrl ?? 'https://api.openai.com/v1';
 
   const openai = new OpenAI({
     apiKey: apiKey,

--- a/src/handlers/openai.ts
+++ b/src/handlers/openai.ts
@@ -45,19 +45,22 @@ export async function OpenAIHandler(
 export async function OpenAIHandler(
   params: HandlerParams,
 ): Promise<ResultNotStreaming | ResultStreaming> {
-  const apiKey = params.apiKey ?? process.env.OPENAI_API_KEY;
+  const { apiKey: providedApiKey, baseUrl: providedBaseUrl, ...completionsParams } = params;
+  const apiKey = providedApiKey ?? process.env.OPENAI_API_KEY;
+  const baseUrl = providedBaseUrl ?? 'https://api.openai.com';
 
   const openai = new OpenAI({
     apiKey: apiKey,
+    baseURL: baseUrl,
   });
 
   if (params.stream) {
     const response = await openai.chat.completions.create({
-      ...params,
+      ...completionsParams,
       stream: params.stream,
     });
     return toStreamingResponse(response);
   }
 
-  return openai.chat.completions.create({ ...params, stream: false });
+  return openai.chat.completions.create({ ...completionsParams, stream: false });
 }


### PR DESCRIPTION
This Pull Request introduces two improvements to the library:

## Parameter Separation in OpenAIHandler (see issue #12):
**Issue Addressed:** Previously, when apiKey and baseUrl parameters were passed to the OpenAIHandler, an error was thrown due to parameter conflicts. This was caused by the direct passing of these parameters, among others, to the completion function using the spread operator.
**Solution Implemented:** The OpenAIHandler has been modified to distinguish between initialization parameters (apiKey, baseUrl) and the parameters required for the completions API call. Now, only the necessary parameters are explicitly passed to the completions API, resolving the error.

## Support for OpenAI-Compatible Servers (see issue #11):
**Issue Addressed:** The library lacked support for OpenAI-compatible servers, such as LocalAI.
**Solution Implemented:** An additional openai/ prefix has been defined within the model routing function. This ensures that when users specify a model name like openai/llama2, the library automatically utilizes the OpenAIHandler. This approach is similar to the library's handling of official gpt* models and is inspired by the approach used in the litellm Python package.
Both changes aim to enhance the library's functionality and user experience. The update to the OpenAIHandler ensures more robust handling of initialization parameters, while the support for OpenAI-compatible servers broadens the library's applicability and flexibility.