### PR TITLE
Add DeepL integration and corresponding tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   "dependencies": {
     "@anthropic-ai/sdk": "^0.6.2",
     "cohere-ai": "^6.2.2",
+    "deepl-node": "^1.27.0",
     "eventsource": "^2.0.2",
     "js-tiktoken": "^1.0.7",
     "openai": "^4.11.1",

--- a/src/completion.ts
+++ b/src/completion.ts
@@ -16,6 +16,7 @@ import { AI21Handler } from './handlers/ai21';
 import { ReplicateHandler } from './handlers/replicate';
 import { DeepInfraHandler } from './handlers/deepinfra';
 import { MistralHandler } from './handlers/mistral';
+import { DeepLHandler } from './handlers/deepL';
 
 export const MODEL_HANDLER_MAPPINGS: Record<string, Handler> = {
   'claude-': AnthropicHandler,
@@ -27,6 +28,7 @@ export const MODEL_HANDLER_MAPPINGS: Record<string, Handler> = {
   'replicate/': ReplicateHandler,
   'deepinfra/': DeepInfraHandler,
   'mistral/': MistralHandler,
+  'deepl/': DeepLHandler,
 };
 
 export async function completion(

--- a/src/handlers/deepL.ts
+++ b/src/handlers/deepL.ts
@@ -1,0 +1,100 @@
+import * as deepl from 'deepl-node';
+
+import {
+  HandlerParams,
+  HandlerParamsNotStreaming,
+  HandlerParamsStreaming,
+  ResultNotStreaming,
+  ResultStreaming,
+  StreamingChunk,
+} from '../types';
+import { combinePrompts } from '../utils/combinePrompts';
+import { getUnixTimestamp } from '../utils/getUnixTimestamp';
+import { toUsage } from '../utils/toUsage';
+
+// The DeepL API is a translation API, so we map it onto the chat interface by
+// encoding the target language in the model string, e.g. `deepl/fr`,
+// `deepl/en-US`, `deepl/de`. The combined prompt is the text to translate.
+function parseTargetLang(model: string): deepl.TargetLanguageCode {
+  const targetLang = model.split('deepl/')[1];
+  if (!targetLang) {
+    throw new Error(
+      `Model: ${model} is missing a target language. Use the format 'deepl/<target-lang>', e.g. 'deepl/fr'.`,
+    );
+  }
+  return targetLang as deepl.TargetLanguageCode;
+}
+
+// DeepL does not stream, so we yield the full translation as a single chunk,
+// mirroring the other non-streaming providers in this library.
+// eslint-disable-next-line @typescript-eslint/require-await
+async function* toStream(
+  text: string,
+  model: string,
+  prompt: string,
+): AsyncIterable<StreamingChunk> {
+  yield {
+    model,
+    created: getUnixTimestamp(),
+    usage: toUsage(prompt, text),
+    choices: [
+      {
+        delta: {
+          content: text,
+          role: 'assistant',
+        },
+        finish_reason: 'stop',
+        index: 0,
+      },
+    ],
+  };
+}
+
+export async function DeepLHandler(
+  params: HandlerParamsNotStreaming,
+): Promise<ResultNotStreaming>;
+
+export async function DeepLHandler(
+  params: HandlerParamsStreaming,
+): Promise<ResultStreaming>;
+
+export async function DeepLHandler(
+  params: HandlerParams,
+): Promise<ResultNotStreaming | ResultStreaming>;
+
+export async function DeepLHandler(
+  params: HandlerParams,
+): Promise<ResultNotStreaming | ResultStreaming> {
+  const apiKey = params.apiKey ?? process.env.DEEPL_API_KEY!;
+  const targetLang = parseTargetLang(params.model);
+
+  const translator = new deepl.Translator(apiKey);
+  const textsCombined = combinePrompts(params.messages);
+
+  // Source language is auto-detected by passing null.
+  const result = await translator.translateText(
+    textsCombined,
+    null,
+    targetLang,
+  );
+
+  if (params.stream) {
+    return toStream(result.text, params.model, textsCombined);
+  }
+
+  return {
+    model: params.model,
+    created: getUnixTimestamp(),
+    usage: toUsage(textsCombined, result.text),
+    choices: [
+      {
+        message: {
+          content: result.text,
+          role: 'assistant',
+        },
+        finish_reason: 'stop',
+        index: 0,
+      },
+    ],
+  };
+}

--- a/tests/handlers/getHandler.test.ts
+++ b/tests/handlers/getHandler.test.ts
@@ -3,6 +3,7 @@ import { AI21Handler } from '../../src/handlers/ai21';
 import { AnthropicHandler } from '../../src/handlers/anthropic';
 import { CohereHandler } from '../../src/handlers/cohere';
 import { DeepInfraHandler } from '../../src/handlers/deepinfra';
+import { DeepLHandler } from '../../src/handlers/deepL';
 import { getHandler } from '../../src/handlers/getHandler';
 import { MistralHandler } from '../../src/handlers/mistral';
 import { OllamaHandler } from '../../src/handlers/ollama';
@@ -26,6 +27,8 @@ describe('getHandler', () => {
     { model: 'replicate/test/test', expectedHandler: ReplicateHandler },
     { model: 'deepinfra/test/test', expectedHandler: DeepInfraHandler },
     { model: 'mistral/mistral-tiny', expectedHandler: MistralHandler },
+    { model: 'deepl/fr', expectedHandler: DeepLHandler },
+    { model: 'deepl/en-US', expectedHandler: DeepLHandler },
     { model: 'unknown', expectedHandler: null },
   ])(
     'should return the correct handler for a given model name',


### PR DESCRIPTION
This pull request adds support for DeepL translation as a handler in the codebase. It introduces a new `DeepLHandler` that allows users to access DeepL's translation API through the existing chat interface, by specifying the target language in the model string (e.g., `deepl/fr`). The handler is integrated into the handler mapping and tested for correct routing. The most important changes are:

**DeepL Handler Integration:**

* Added the `deepl-node` package as a new dependency in `package.json` to enable DeepL API access.
* Implemented a new `DeepLHandler` in `src/handlers/deepL.ts` that maps chat prompts to DeepL translations, supports both streaming and non-streaming interfaces, and parses the target language from the model string.
* Registered `DeepLHandler` in `MODEL_HANDLER_MAPPINGS` in `src/completion.ts` to route model names prefixed with `deepl/` to the new handler. [[1]](diffhunk://#diff-cc3c09cd0e907b36fa79b43e743693740528eeaae34247576656613a9b115935R19) [[2]](diffhunk://#diff-cc3c09cd0e907b36fa79b43e743693740528eeaae34247576656613a9b115935R31)

**Testing and Validation:**

* Added `DeepLHandler` imports and test cases in `tests/handlers/getHandler.test.ts` to ensure the handler is correctly selected for models like `deepl/fr` and `deepl/en-US`. [[1]](diffhunk://#diff-fb02505a9560d2b0b2dcd411e2018574bd88804e090424db75f83f4ccba89525R6) [[2]](diffhunk://#diff-fb02505a9560d2b0b2dcd411e2018574bd88804e090424db75f83f4ccba89525R30-R31)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds DeepL translation API support to the codebase by introducing a new `DeepLHandler` that integrates DeepL into the existing chat interface. The handler allows users to perform translations by specifying the target language in the model string format (e.g., `deepl/fr` for French, `deepl/en-US` for US English). The implementation maps chat prompts to translation requests, supports both streaming and non-streaming interfaces, and includes corresponding test cases to validate the handler routing.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `package.json` |
| 2 | `src/completion.ts` |
| 3 | `src/handlers/deepL.ts` |
| 4 | `tests/handlers/getHandler.test.ts` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->